### PR TITLE
From<Matrix4x4> for Matrix4<f32> instead of Into<Matrix4<f32>> for Matrix4x4

### DIFF
--- a/src/math/matrix4.rs
+++ b/src/math/matrix4.rs
@@ -33,11 +33,11 @@ impl From<Matrix4<f32>> for Matrix4x4 {
 }
 
 #[cfg(feature = "cgmath")]
-impl Into<Matrix4<f32>> for Matrix4x4 {
-    fn into(self) -> Matrix4<f32> {
-        Matrix4::new(self.a1, self.b1, self.c1, self.d1,
-                     self.a2, self.b2, self.c2, self.d2,
-                     self.a3, self.b3, self.c3, self.d3,
-                     self.a4, self.b4, self.c4, self.d4)
+impl From<Matrix4x4> for Matrix4<f32> {
+    fn from(mat: Matrix4x4) -> Matrix4<f32> {
+        Matrix4::new(mat.a1, mat.b1, mat.c1, mat.d1,
+                     mat.a2, mat.b2, mat.c2, mat.d2,
+                     mat.a3, mat.b3, mat.c3, mat.d3,
+                     mat.a4, mat.b4, mat.c4, mat.d4)
     }
 }


### PR DESCRIPTION
From [the `Into` docs](https://doc.rust-lang.org/std/convert/trait.Into.html):
> Library authors should not directly implement this trait, but should prefer implementing the From trait, which offers greater flexibility and provides an equivalent Into implementation for free, thanks to a blanket implementation in the standard library.

I bumped into a situation today where I needed the `From` implementation for this but didn't have it.