### PR TITLE
Fix VertexWeightIter

### DIFF
--- a/src/scene/mesh.rs
+++ b/src/scene/mesh.rs
@@ -19,7 +19,7 @@ define_type_and_iterator_indirect! {
     struct BoneIter
 }
 
-define_type_and_iterator_indirect! {
+define_type_and_iterator! {
     /// Vertex weight type
     struct VertexWeight(&AiVertexWeight)
     /// Vertex weight iterator type.
@@ -141,7 +141,7 @@ impl<'a> Bone<'a> {
     }
 
     pub fn weight_iter(&self) -> VertexWeightIter {
-        VertexWeightIter::new(self.weights as *const *const AiVertexWeight,
+        VertexWeightIter::new(self.weights as *const AiVertexWeight,
                       self.num_weights as usize)
     }
 


### PR DESCRIPTION
[`AiBone`'s `weight`s are behind a single pointer](https://github.com/Eljay/assimp-sys/blob/c1c0f9a90344a6354ed3d561d850dec57723a330/src/mesh.rs#L29).